### PR TITLE
ci: re-enable Downgrade job (strict, runs naturally)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,7 +12,7 @@ on:
       - 'docs/**'
 jobs:
   downgrade:
-    if: false
+    # Runs strict (allow_reresolve=false); expected RED until modern Lux/AD stack resolves (test reworked in #49)
     name: "Downgrade"
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:


### PR DESCRIPTION
Removes the `if: false` skip on the Downgrade job so it actually runs.

downgrade re-enabled strict; intentionally RED (natural failure, not disabled) pending modern Lux/AD stack (test reworked in #49); auto-greens when that resolves.

Kept strict: no `allow-reresolve` input added (defaults to strict), julia stays `1.10`, no version floors lowered.

---
Please ignore until reviewed by @ChrisRackauckas.