### PR TITLE
docs: fix missing_docs failure on main by documenting is_leaf

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,4 +2,5 @@
 
 ```@docs
 hasbranching
+is_leaf
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,11 +28,16 @@ end # true
 end # false
 ```
 
-## This package uses Cassette internally?
+## How does this package work internally?
 
-Yes, because this is how it's currently known how to be done. If you have an alternative
-implementation which uses the undocumented compiler plugins interface, we would happily
-accept the PR!
+`hasbranching` inspects the type-inferred but unoptimized IR of the function
+(via `code_typed(f, argtypes; optimize = false)`) and checks for `GotoIfNot`
+nodes, which represent value-dependent conditional branches. Constructs that do
+not introduce data-dependent control flow, such as `ifelse`, do not produce
+`GotoIfNot` nodes and are therefore reported as branch-free.
+
+If a function produces a false positive because its branches are known to
+resolve at compile time, opt it out with [`is_leaf`](@ref).
 
 ## Contributing
 


### PR DESCRIPTION
## Problem

PR #55 (Julia 1.12 fix) added a new exported function `is_leaf` with a docstring, but did not reference it in the manual. Documenter runs with `:missing_docs` as an error (not in `warnonly`), so the **Documentation build now fails on `main`**:

```
Error: 1 docstring not included in the manual:
ERROR: LoadError: `makedocs` encountered an error [:missing_docs] -- terminating build before rendering.
```

(See the failing Documentation run on the #55 merge commit.)

## Fix

- Add `is_leaf` to `docs/src/api.md`.
- Replace the now-outdated "This package uses Cassette internally?" section in `docs/src/index.md` with a short description of the `code_typed`-based branch detection that replaced Cassette.

## Verification

Built locally:

```
julia --project=docs docs/make.jl
```

Builds cleanly — no `:missing_docs` error (only the expected "skipping deployment" notice for a local build).

> **Note:** Please ignore until reviewed by @ChrisRackauckas.