### PR TITLE
Add ExplicitImports.jl checks to QA via SciMLTesting run_qa

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ authors = ["SciML"]
 ComponentArrays = "0.15"
 Random = "1.10"
 SafeTestsets = "0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.4"
 Test = "1.10"
 julia = "1.10"
 

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ authors = ["SciML"]
 ComponentArrays = "0.15"
 Random = "1.10"
 SafeTestsets = "0.1"
-SciMLTesting = "1.4"
+SciMLTesting = "1.5"
 Test = "1.10"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 FunctionProperties = "f62d2435-5019-4c03-9749-2d4c77af0cbc"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -11,8 +12,9 @@ FunctionProperties = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
+ExplicitImports = "1.15"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.4"
 Test = "1"
 julia = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,8 @@
+# Aqua is otherwise a transitive dep of SciMLTesting, but it is kept here as a
+# direct dep because Aqua's `Method ambiguity` check spawns a fresh subprocess
+# that `using Aqua` against this env's load path, where only direct deps resolve.
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 FunctionProperties = "f62d2435-5019-4c03-9749-2d4c77af0cbc"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -12,9 +14,8 @@ FunctionProperties = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
-ExplicitImports = "1.15"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1.4"
+SciMLTesting = "1.5"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,14 +1,17 @@
-using FunctionProperties, Aqua, JET, Test
+using FunctionProperties, Aqua, JET, ExplicitImports, SciMLTesting
 
-@testset "Aqua" begin
-    # deps_compat disabled: missing [compat] for the Pkg test extra.
-    # Tracked in https://github.com/SciML/FunctionProperties.jl/issues/54
-    Aqua.test_all(FunctionProperties; deps_compat = false)
-    @test_broken false  # Aqua deps_compat: missing compat for Pkg extra — tracked in https://github.com/SciML/FunctionProperties.jl/issues/54
-end
-
-@testset "JET" begin
-    # JET finds `Cassette.m is not defined` in overdub(::typeof(nameof), ...).
-    # Tracked in https://github.com/SciML/FunctionProperties.jl/issues/54
-    @test_broken false  # JET: Cassette.m is not defined in overdub(::typeof(nameof), ...) — tracked in https://github.com/SciML/FunctionProperties.jl/issues/54
-end
+# `hasbranching` is a compiler-introspection utility: it `code_typed`s `f` and scans the
+# resulting IR for `Core.GotoIfNot` nodes, and builds the dispatch signature with
+# `Core.Typeof`. Both names are internal to `Core` with no public equivalent
+# (`typeof` differs from `Core.Typeof` on type-valued arguments, and `Base.typesof`
+# is itself non-public), so these two accesses are ignored in the public-API checks.
+run_qa(
+    FunctionProperties;
+    Aqua = Aqua,
+    JET = JET, jet = true,
+    ExplicitImports = ExplicitImports, explicit_imports = true,
+    ei_kwargs = (;
+        all_explicit_imports_are_public = (; ignore = (:GotoIfNot,)),
+        all_qualified_accesses_are_public = (; ignore = (:Typeof,)),
+    )
+)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,4 +1,4 @@
-using FunctionProperties, Aqua, JET, ExplicitImports, SciMLTesting
+using SciMLTesting, FunctionProperties, JET, Test
 
 # `hasbranching` is a compiler-introspection utility: it `code_typed`s `f` and scans the
 # resulting IR for `Core.GotoIfNot` nodes, and builds the dispatch signature with
@@ -7,9 +7,7 @@ using FunctionProperties, Aqua, JET, ExplicitImports, SciMLTesting
 # is itself non-public), so these two accesses are ignored in the public-API checks.
 run_qa(
     FunctionProperties;
-    Aqua = Aqua,
-    JET = JET, jet = true,
-    ExplicitImports = ExplicitImports, explicit_imports = true,
+    explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (; ignore = (:GotoIfNot,)),
         all_qualified_accesses_are_public = (; ignore = (:Typeof,)),


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What

Wires all six [ExplicitImports.jl](https://github.com/ericphanson/ExplicitImports.jl) checks into the `QA` test group through SciMLTesting's `run_qa(...; ExplicitImports = ExplicitImports, explicit_imports = true, ei_kwargs = ...)`:

- `no_implicit_imports`
- `no_stale_explicit_imports`
- `all_explicit_imports_via_owners`
- `all_qualified_accesses_via_owners`
- `all_qualified_accesses_are_public`
- `all_explicit_imports_are_public`

## Violations and how they were resolved (FIX > DECLARE-PUBLIC > IGNORE)

`print_explicit_imports(FunctionProperties; report_non_public = true)` surfaced exactly two violations, both internal `Core` accesses inherent to `hasbranching`, which is a compiler-introspection utility:

| Name | Where | Check | Resolution |
| --- | --- | --- | --- |
| `Core.GotoIfNot` | `using Core: GotoIfNot` (src line 3) | `all_explicit_imports_are_public` | minimal documented ignore |
| `Core.Typeof` | `Core.Typeof.(x)` (src line 47) | `all_qualified_accesses_are_public` | minimal documented ignore |

Neither can be cleanly fixed:

- `Core.GotoIfNot` is the IR node type that `hasbranching` scans `code_typed` output for. It is non-public in `Core` and has no public alias.
- `Core.Typeof` builds the dispatch-signature tuple type passed to `code_typed`. It is **not** interchangeable with the public `typeof`: for a type-valued argument `x = Int`, `Core.Typeof(Int)` is `Type{Int64}` (the dispatch signature) while `typeof(Int)` is `DataType`. The equivalent `Base.typesof` is itself non-public, so swapping would just relocate the violation.

Both are therefore added to a **minimal, documented per-check `ei_kwargs` ignore-list** (the source line itself is unchanged, so no behavior change). FunctionProperties has no genuinely-public-but-unexported names of its own, so no `public`/`export` declarations were needed.

## Also in this PR

Folds Aqua and JET into the same `run_qa` call and drops the two stale `@test_broken false` placeholders (the `#54` workarounds):

- Aqua now passes with `deps_compat` **enabled** — the root `Project.toml` already carries `[compat]` for every test extra, so the `deps_compat = false` workaround is obsolete.
- JET typo-mode passes — the `Cassette.m is not defined` failure was eliminated when #55 replaced Cassette with `code_typed`.

Leaving `@test_broken false` in place would now error as an *unexpected pass*, so removing the placeholders and running the real checks is the correct fix.

## Test deps

- `test/qa/Project.toml`: add `ExplicitImports` (compat `1.15`), bump `SciMLTesting` floor to `1.4` (the release whose `run_qa` supports ExplicitImports).
- Root `Project.toml`: bump `SciMLTesting` compat floor to `1.4`.

## Verification (local, Julia 1.12)

`GROUP=QA julia --project=. -e 'using Pkg; withenv("GROUP"=>"QA") do; Pkg.test("FunctionProperties"); end'`:

```
Test Summary: | Pass  Total   Time
QA/qa.jl      |   18     18  41.6s
     Testing FunctionProperties tests passed
```

The six ExplicitImports checks individually (with the configured ignores):

```
Test Summary:                       | Pass  Total  Time
ExplicitImports (6 checks)          |    6      6  2.8s
  no_implicit_imports               |    1      1
  no_stale_explicit_imports         |    1      1
  all_explicit_imports_via_owners   |    1      1
  all_qualified_accesses_via_owners |    1      1
  all_qualified_accesses_are_public |    1      1
  all_explicit_imports_are_public   |    1      1
```

Runic-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)