### PR TITLE
QA: ignore Core/Base IR-introspection internals in public-API check

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,15 +1,27 @@
 using SciMLTesting, FunctionProperties, JET, Test
 
 # `hasbranching` is a compiler-introspection utility: it `code_typed`s `f` and scans the
-# resulting IR for `Core.GotoIfNot` nodes, and builds the dispatch signature with
-# `Core.Typeof`. Both names are internal to `Core` with no public equivalent
-# (`typeof` differs from `Core.Typeof` on type-valued arguments, and `Base.typesof`
-# is itself non-public), so these two accesses are ignored in the public-API checks.
+# resulting typed IR for value-dependent branches, so it necessarily reaches into the
+# `Core`/`Base` IR and inference internals, none of which have a public equivalent:
+#   - `GotoIfNot` (explicit import via `using Core: GotoIfNot`) is the conditional-branch IR node.
+#   - `CodeInfo`/`SSAValue`/`SlotNumber`/`Argument` are typed-IR node types scanned in the body.
+#   - `Const`/`PartialStruct` are inference lattice element types read off the IR.
+#   - `MethodInstance` is the resolved-call type used to recurse through static calls.
+#   - `Typeof` builds the dispatch signature (`typeof` differs from `Core.Typeof` on
+#     type-valued arguments, and `Base.typesof` is itself non-public).
+#   - `code_typed_by_type` is the non-public typed-IR entry point (`Base.code_typed_by_type`).
+# All of these are Core/Base compiler-introspection internals with no public API, so they are
+# ignored in the public-API checks.
 run_qa(
     FunctionProperties;
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (; ignore = (:GotoIfNot,)),
-        all_qualified_accesses_are_public = (; ignore = (:Typeof,)),
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                :Typeof, :Argument, :CodeInfo, :Const, :MethodInstance,
+                :PartialStruct, :SSAValue, :SlotNumber, :code_typed_by_type,
+            ),
+        ),
     )
 )


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Problem

The QA `julia 1` (1.11+) lane fails on the ExplicitImports `all_qualified_accesses_are_public` check. `hasbranching` is a compiler-introspection utility that `code_typed`s `f` and scans the resulting typed IR, so it necessarily reaches into `Core`/`Base` IR and inference internals that have no public equivalent. The ignore tuple only listed `:Typeof`, so the other eight internals were flagged:

```
- `Argument` is not public in `Core` ... src/FunctionProperties.jl:123
- `CodeInfo` is not public in `Core` ... src/FunctionProperties.jl:98
- `Const` is not public in `Core` ... src/FunctionProperties.jl:130
- `MethodInstance` is not public in `Core` ... src/FunctionProperties.jl:140
- `PartialStruct` is not public in `Core` ... src/FunctionProperties.jl:254
- `SSAValue` is not public in `Core` ... src/FunctionProperties.jl:120
- `SlotNumber` is not public in `Core` ... src/FunctionProperties.jl:125
- `code_typed_by_type` is not public in `Base` ... src/FunctionProperties.jl:89
```

## Fix

Extend the `all_qualified_accesses_are_public` `ignore` tuple in `test/qa/qa.jl` from `(:Typeof,)` to also cover `:Argument, :CodeInfo, :Const, :MethodInstance, :PartialStruct, :SSAValue, :SlotNumber, :code_typed_by_type`. These are all Core/Base compiler-introspection internals (typed-IR node types, inference lattice element types, the resolved-call type, and the non-public typed-IR entry point) with no public API — the same rationale that already applies to `Typeof`/`GotoIfNot`. `all_explicit_imports_are_public = (; ignore = (:GotoIfNot,))` is left unchanged. No source change, no compat/floor change.

## Validation (local)

- QA group (`GROUP=QA` `Pkg.test`) on Julia **1.12.6** (the `julia 1` lane): `QA/qa.jl | 18 18` — all pass (was 17 pass / 1 error before).
- QA group on Julia **1.10.11** (`lts` lane): `QA/qa.jl | 16 16` — all pass (the two public-API checks are skipped pre-1.11).
- Reproduced the pre-fix failure (exactly the 8 names above) before editing; confirmed all clear afterward.
- Ran Runic on the changed file.

Resolved deps at verification: SciMLTesting 1.8.0, ExplicitImports 1.15.0, Aqua 0.8.16, JET 0.11.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
