### PR TITLE
Allow SciMLTesting v2 in QA compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ authors = ["SciML"]
 ComponentArrays = "0.15"
 Random = "1.10"
 SafeTestsets = "0.1"
-SciMLTesting = "1.5"
+SciMLTesting = "1.5, 2.1"
 Test = "1.10"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -16,6 +16,6 @@ FunctionProperties = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1.5"
+SciMLTesting = "1.5, 2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Expands `SciMLTesting` compat from `1.5` to `1.5, 2.1` in the root package environment.
- Applies the same compat expansion in the QA environment.

## Local verification
- `timeout 3600 git diff --check` passed.
- `JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot: timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 -e 'using TOML; root = TOML.parsefile("Project.toml"); qa = TOML.parsefile("test/qa/Project.toml"); @assert root["compat"]["SciMLTesting"] == "1.5, 2.1"; @assert qa["compat"]["SciMLTesting"] == "1.5, 2.1"; println("SciMLTesting compat OK in root and QA")'` passed.\n- `JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot: timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/.runic_env -e 'using Runic; ret = Runic.main(["--check", "."]); ret === nothing ? exit(0) : exit(ret)'` passed.\n- `JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot: timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.activate("."); Pkg.test(; coverage=false)'` passed with `SciMLTesting v2.2.0`; root tests reported `272/272` passing.\n- `JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot: timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.activate("test/qa"); Pkg.instantiate(); include("test/qa/qa.jl")'` passed with `SciMLTesting v2.2.0`; QA reported `17/17` passing.\n