### PR TITLE
Tighten SciMLTesting compat to v2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ authors = ["SciML"]
 ComponentArrays = "0.15"
 Random = "1.10"
 SafeTestsets = "0.1"
-SciMLTesting = "1.5, 2.1"
+SciMLTesting = "2.1"
 Test = "1.10"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -16,6 +16,6 @@ FunctionProperties = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1.5, 2.1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- Restrict SciMLTesting compat to `2.1` in the root package project.
- Restrict SciMLTesting compat to `2.1` in the QA project.

## Validation
- `git diff --check`
- Runic.jl v1.7.0 over git-tracked Julia files
- `julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`\n- `julia +1.10 --startup-file=no --project=test/qa -e 'using Pkg; Pkg.instantiate(); include("test/qa/qa.jl")'`\n\n## Notes\n- Local validation used a repo-local Julia depot, then generated depot/temp directories were removed.