### PR TITLE
fix: Improve constant-argument inference for Julia 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FunctionProperties"
 uuid = "f62d2435-5019-4c03-9749-2d4c77af0cbc"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["SciML"]
 
 [deps]

--- a/src/hasbranching.jl
+++ b/src/hasbranching.jl
@@ -431,11 +431,15 @@ function _const_infer_src(@nospecialize(sig), argtypes)
         return nothing
     end
     mi = try
-        Base.specialize_method(m, sig, Core.svec())
+        # `specialize_method` lives in the compiler module; `Base.specialize_method` does not
+        # exist on 1.10, where its absence silently disabled the whole constant recursion.
+        _CC.specialize_method(m, sig, Core.svec())
     catch
         return nothing
     end
-    overridden = BitVector(x isa Core.Const for x in argtypes)
+    # `_CC.BitVector`: on ≤1.11 `Core.Compiler` bootstraps its own `BitVector`, distinct from
+    # `Base.BitVector`, and `InferenceResult` accepts only the compiler-owned one.
+    overridden = _CC.BitVector(Bool[x isa Core.Const for x in argtypes])
     src0 = try
         _CC.retrieve_code_info(mi, Base.get_world_counter())
     catch

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -175,6 +175,14 @@ tbp = TwoBufferParams([1.0], [2.0])
 
 @test FunctionProperties.hasbranching(rhs_real_branch, 1.0, tbp)   # genuine branch: always reported
 @test FunctionProperties.hasbranching(rhs_dynamic_index, tbp, 1)   # dynamic index: always reported
+
+# The functional gate exists so a future compiler shift degrades to the plain type recursion
+# instead of erroring — but on every *supported* Julia version the probe must succeed, or the
+# refutation blocks below silently skip and `rhs_const_index` is reported as a false positive.
+# (On ≤1.11 this needs the compiler-owned `specialize_method` and `BitVector`: `Base` has no
+# `specialize_method` there, and `Core.Compiler.BitVector` is a distinct bootstrapped type.)
+VERSION >= v"1.10" && (@test FunctionProperties._const_prop_capable())
+
 if FunctionProperties._const_prop_capable()
     @test !FunctionProperties.hasbranching(rhs_const_index, tbp)   # constant index folds away
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Fable generated this fix for a test involving `hasbranching` that was passing on Julia 1.12, but failed on Julia 1.10.
