### PR TITLE
Fix docs cleanup shell quoting

### DIFF
--- a/.github/workflows/DocsPreviewCleanup.yml
+++ b/.github/workflows/DocsPreviewCleanup.yml
@@ -19,7 +19,7 @@ jobs:
               git config user.email "documenter@juliadocs.github.io"
               git rm -rf "previews/PR$PRNUM"
               git commit -m "delete preview"
-              git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+              git branch gh-pages-new "$(echo "delete history" | git commit-tree "HEAD^{tree}")"
               git push --force origin gh-pages-new:gh-pages
             fi
         env:


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- Quote the commit ID returned by `git commit-tree` before passing it to `git branch`.
- Quote the `HEAD^{tree}` revision expression.
- Remove the repo-wide actionlint `SC2046` and `SC1083` findings without changing cleanup behavior.

## Root cause

The faulty cleanup workflow was introduced in `3a43dd9f0e5b4150dcd1aa3d81215ccd83b604bb` (`First version`). Direct history inspection confirms the file is absent from its parent and is introduced with the unquoted command substitution and revision expression.

## Local verification

- `actionlint` from the repository root: passed.
- `git diff --check`: passed.
- `/home/crackauc/.juliaup/bin/julialauncher +1.12 --startup-file=no -m Runic --check .`: passed.
- Executed the exact rewritten command in a temporary Git repository and verified the created branch has the same tree as `HEAD` and commit subject `delete history`: passed.