### PR TITLE
Enable FunctionProperties rendered docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -33,6 +33,7 @@ using SciMLTesting, FunctionProperties, JET, Test
 # ignored in the public-API checks.
 run_qa(
     FunctionProperties;
+    api_docs_kwargs = (; rendered = true),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (; ignore = (:GotoIfNot,)),


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Enable SciMLTesting rendered public API docs QA for FunctionProperties.
- No source, docs, or behavior changes. The exported API already has source docstrings and explicit rendered `@docs` entries in `docs/src/api.md`.
- This is separate from the unrelated docs cleanup workflow PR #71.

## Local validation
- `git diff --check` passed.
- QA passed with SciMLTesting v2.2.0: `Quality Assurance | 18 pass, 18 total`.
- Docs build completed with `include("docs/make.jl")`; note the docs config already has pre-existing `warnonly` entries, and local deployment was skipped.
- `Pkg.test()` passed: `Core/core_tests.jl` 272/272.
- Runic v1.7.0 passed over `src`, `test`, and `docs`.
