### PR TITLE
Use default public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -33,7 +33,6 @@ using SciMLTesting, FunctionProperties, JET, Test
 # ignored in the public-API checks.
 run_qa(
     FunctionProperties;
-    api_docs_kwargs = (; rendered = true),
     explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (; ignore = (:GotoIfNot,)),


### PR DESCRIPTION
Remove the repository-specific rendered API-docs option and use the standard SciMLTesting public API documentation check.

Validation:
- Runic 1.7 with docstrings
- `GROUP=QA Pkg.test()`
- `Pkg.test()`

Ignore until reviewed by @ChrisRackauckas.