### PR TITLE
Migrate FunctionProperties QA to SciMLTesting 2.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ authors = ["SciML"]
 ComponentArrays = "0.15"
 Random = "1.10"
 SafeTestsets = "0.1"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1.10"
 julia = "1.10"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,13 +13,7 @@ makedocs(
     sitename = "FunctionProperties.jl",
     authors = "Chris Rackauckas",
     modules = [FunctionProperties],
-    clean = true, doctest = false, linkcheck = true,
-    warnonly = [
-        :doctest,
-        :linkcheck,
-        :parse_error,
-        :example_block,        # Other available options are        # :autodocs_block, :cross_references, :docs_block, :eval_block, :example_block, :footnote, :meta_block, :missing_docs, :setup_block
-    ],
+    clean = true, doctest = true, linkcheck = true,
     format = Documenter.HTML(
         analytics = "UA-90474609-3",
         assets = ["assets/favicon.ico"],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -42,7 +42,7 @@ resolve at compile time, opt it out with [`is_leaf`](@ref).
 ## Contributing
 
   - Please refer to the
-    [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://github.com/SciML/ColPrac/blob/master/README.md)
+    [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://sciml.github.io/ColPrac/)
     for guidance on PRs, issues, and other matters relating to contributing to SciML.
 
   - See the [SciML Style Guide](https://github.com/SciML/SciMLStyle) for common coding practices and other style decisions.

--- a/src/effects.jl
+++ b/src/effects.jl
@@ -37,6 +37,15 @@ effects analysis must establish both consistency (equal inputs give equal output
 dependence on or mutation of external state) and effect freeness (no observable side effects).
 `false` means *not proven*. The underlying effect queries are compiler internals, so they are
 verified functionally at first use; where they are unavailable the answer is always `false`.
+
+## Example
+
+```jldoctest
+julia> using FunctionProperties
+
+julia> ispure(x -> x^2 + 1, 2.0)
+true
+```
 """
 function ispure(f, x...)
     _effects_capable() || return false
@@ -53,6 +62,15 @@ end
 Check whether the return type of `f` for arguments of the given types is inferred as a single
 concrete type. `false` means inference produced an abstract or `Union` result -- or that the
 call could not be analyzed at all.
+
+## Example
+
+```jldoctest
+julia> using FunctionProperties
+
+julia> isinferable(x -> x + 1, 2.0)
+true
+```
 """
 function isinferable(f, x...)
     sig = Tuple{Core.Typeof(f), Core.Typeof.(x)...}

--- a/src/randomness.jl
+++ b/src/randomness.jl
@@ -15,6 +15,15 @@ call is reachable through statically resolvable calls.
 
 This matters wherever a trace of `f` is replayed, e.g. compiled ReverseDiff tapes freeze the
 random draws of the recording pass, silently changing the semantics of a stochastic `f`.
+
+## Example
+
+```jldoctest
+julia> using FunctionProperties
+
+julia> hasrandomness(x -> x + 1, 2.0)
+false
+```
 """
 function hasrandomness(f, x...)
     sig = Tuple{Core.Typeof(f), Core.Typeof.(x)...}

--- a/src/writeprobe.jl
+++ b/src/writeprobe.jl
@@ -46,6 +46,18 @@ The certificate covers writes through the selected argument reference and reject
 recorded write. Aliases of the selected array reachable through the *other* arguments are
 detected one structural level deep (arguments themselves and elements of tuples or arrays of
 arrays); deeper aliasing is outside the certificate.
+
+## Example
+
+```jldoctest
+julia> using FunctionProperties
+
+julia> hasmutation(x -> sum(abs2, x), [1.0, 2.0])
+false
+
+julia> hasmutation(x -> (x[1] = 0; x), [1.0, 2.0])
+true
+```
 """
 function hasmutation(f, x...; arg = (:))
     idx = _wrt_indices(arg, length(x))

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -9,13 +9,10 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-FunctionProperties = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -33,7 +33,6 @@ using SciMLTesting, FunctionProperties, JET, Test
 # ignored in the public-API checks.
 run_qa(
     FunctionProperties;
-    explicit_imports = true,
     ei_kwargs = (;
         all_explicit_imports_are_public = (; ignore = (:GotoIfNot,)),
         all_qualified_accesses_are_public = (;


### PR DESCRIPTION
## Summary
- require SciMLTesting 2.4 and use its strict QA defaults
- remove the QA source-path override and redundant explicit-import setting
- add runnable definition-site examples for public property predicates and enforce doctests/link checks

## Validation
- `Pkg.test()` (Julia 1.10): 272/272 passed
- strict SciMLTesting 2.4 QA (Julia 1.10): 19/19 passed
- Documenter build with doctests, cross-reference checks, document checks, and link checking passed
- Runic check and `git diff --check` passed

Ignore until reviewed by @ChrisRackauckas.