### PR TITLE
QA: ignore Compiler-owned BitVector/specialize_method in ExplicitImports checks

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -26,6 +26,12 @@ using SciMLTesting, FunctionProperties, JET, Test
 #     method with constant argument types". This dependency is deliberately confined behind a
 #     functional capability probe (`_const_prop_capable`) so the package degrades to the plain
 #     type scan wherever these internals change shape.
+#   - `BitVector` marks which argtypes are `Core.Const`. It is reached through the `Compiler`
+#     module (not `Base`) because on Julia <= 1.11 the compiler bootstraps its own `BitVector`
+#     distinct from `Base.BitVector`, and `InferenceResult` accepts only that compiler-owned one.
+#     `specialize_method` is likewise only reachable via `Compiler` (`Base.specialize_method`
+#     does not exist on 1.10). On 1.12 `Base.which` reports `Base` as their owner, so both are
+#     also ignored in `all_qualified_accesses_via_owners`, not just the public-API check.
 #   - `TwicePrecision` appears only in a constructor disambiguation that Aqua requires: Base
 #     defines `(::Type{T<:Number})(::Base.TwicePrecision)`, which is ambiguous against the
 #     degree tracer's generic constructor.
@@ -35,9 +41,10 @@ run_qa(
     FunctionProperties;
     ei_kwargs = (;
         all_explicit_imports_are_public = (; ignore = (:GotoIfNot,)),
+        all_qualified_accesses_via_owners = (; ignore = (:BitVector, :specialize_method)),
         all_qualified_accesses_are_public = (;
             ignore = (
-                :Typeof, :Argument, :CodeInfo, :Compiler, :Const, :GotoNode,
+                :Typeof, :Argument, :BitVector, :CodeInfo, :Compiler, :Const, :GotoNode,
                 :InferenceResult, :InferenceState, :MethodInstance, :NativeInterpreter,
                 :NewvarNode, :PartialStruct, :ReturnNode, :SSAValue, :SlotNumber, :TwicePrecision,
                 :infer_effects, :is_consistent, :is_effect_free, :mightalias,


### PR DESCRIPTION
## Summary

Fixes the QA failure introduced by #70. That PR added `_CC.BitVector` and `_CC.specialize_method` accesses in `src/hasbranching.jl` (where `_CC` is the `Compiler` module) but did not update the `test/qa/qa.jl` ExplicitImports ignore lists. Under SciMLTesting 2.4 the ExplicitImports checks run by default, so on `main` QA now errors on:

- **`all_qualified_accesses_via_owners`** — both `BitVector` and `specialize_method` are owned by `Base` (per `Base.which` on 1.12) but reached through `Compiler`.
- **`all_qualified_accesses_are_public`** — `BitVector` is not public in `Compiler` (`specialize_method` was already ignored here).

Both names *must* be reached via `Compiler` for version-portability, and this is genuinely irreducible:

- On Julia ≤ 1.11 the compiler bootstraps its own `BitVector`, distinct from `Base.BitVector`, and `InferenceResult` accepts only the compiler-owned one.
- `Base.specialize_method` does not exist on 1.10; it is only reachable through `Compiler`.

So the fix is to add them to the QA ignore lists (with an explanatory comment), matching the existing pattern for the other Core/Base compiler-introspection internals this package deliberately depends on.

## Verification

Ran the QA group locally:

- Julia 1.12: `Quality Assurance | 21 pass / 21 total` (previously 19 pass + 2 errored)
- Julia 1.10 LTS: `Quality Assurance | 19 pass / 19 total` (public-API sub-checks correctly skipped on < 1.11)

Runic clean on the changed file.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUqzmEnsjgBHHuMVzQo1GE