### PR TITLE
docs: disable code coverage for the docs build to fix the ispure doctest

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -16,3 +16,10 @@ jobs:
     name: "Documentation"
     uses: "SciML/.github/.github/workflows/documentation.yml@v1"
     secrets: "inherit"
+    with:
+      # Code-coverage instrumentation inserts side-effecting per-line counter writes into every
+      # compiled method, so `Base.infer_effects` reports every function as not effect-free. That
+      # makes `ispure` (and the `_effects_capable` probe it depends on) return `false` under
+      # coverage, which breaks the `ispure` doctest in src/effects.jl. Coverage collected from a
+      # doctest build is meaningless anyway, so disable it for docs.
+      coverage: false


### PR DESCRIPTION
## Summary

Fixes the pre-existing **Documentation** CI failure on `main` (a doctest error in `src/effects.jl:43-48`). This is independent of the QA fix in #75.

### Root cause

The SciML reusable docs workflow (`SciML/.github/.github/workflows/documentation.yml@v1`) defaults `coverage: true`, which runs:

```
julia --project=docs --code-coverage=user docs/make.jl
```

Code-coverage instrumentation inserts side-effecting per-line counter writes into every compiled method. `Base.infer_effects` therefore reports **every** function — including the internal `_effects_capable` probe and the doctest's own `x -> x^2 + 1` — as **not** effect-free. `ispure` (which requires effect-freeness) soundly returns `false` under coverage, so the doctest

```jldoctest
julia> ispure(x -> x^2 + 1, 2.0)
true
```

evaluates to `false` and terminates the build.

This is **not a runtime regression**: `ispure` returns `true` in any normal (non-instrumented) run — how the library is actually used. The doctest was newly enabled in #74 (`doctest = true`, `warnonly` list removed), which is exactly when the docs build started failing (passed at `327c82b`, failed from `f3a5550` onward).

### Fix

There is no sound in-code fix — under coverage, `infer_effects` legitimately reports `!effect_free` for all functions, so `ispure` cannot certify purity there without becoming unsound. Coverage collected from a doctest-only build is meaningless anyway, so disable it for the docs job via the reusable workflow's documented `coverage` input:

```yaml
    with:
      coverage: false
```

This makes the doctest evaluate real behavior (`true`) — no `warnonly`, no doctest edit, no test skipping.

## Verification (local)

- `julia --code-coverage=user ... ispure(x -> x^2 + 1, 2.0)` → `false` (reproduces CI)
- `julia ... ispure(x -> x^2 + 1, 2.0)` → `true`
- `Documenter.doctest(FunctionProperties)` without coverage → `Doctests: FunctionProperties | 1 pass / 1 total`

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUqzmEnsjgBHHuMVzQo1GE